### PR TITLE
MetroTextBox.WithError Property Attribute Fix

### DIFF
--- a/MetroFramework/Controls/MetroTextBox.cs
+++ b/MetroFramework/Controls/MetroTextBox.cs
@@ -337,7 +337,7 @@ namespace MetroFramework.Controls
         private bool _witherror = false;
 
         [DefaultValue(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(False)]
         public bool WithError
         {
             get { return _witherror; }


### PR DESCRIPTION
Changed the `MetroTextBox.WithError` property from `[EditorBrowsable(EditorBrowsableState.Never)]` to `[Browsable(False)]`. 

The `EditorBrowsable` attribute hides the property from appearing in IntelliSense AutoComplete and the Object Browser (unless set to show hidden members) but the `WithError` property was still being listed in the Visual Studio IDE Properties panel. 

(I assume the original intent was to hide this property from showing in the Visual Studio Designer? It doesn't really make sense to have the item visible in the Designer Properties window but not appearing as a member in the code IDE IntelliSense...)
