### PR TITLE
Metro combo box drop down support

### DIFF
--- a/MetroFramework.Demo/MainForm.Designer.cs
+++ b/MetroFramework.Demo/MainForm.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace MetroFramework.Demo
+﻿using MetroFramework.Extensions;
+
+namespace MetroFramework.Demo
 {
     partial class MainForm
     {
@@ -55,6 +57,9 @@
             this.metroTile2 = new MetroFramework.Controls.MetroTile();
             this.metroTile1 = new MetroFramework.Controls.MetroTile();
             this.metroTabPage2 = new MetroFramework.Controls.MetroTabPage();
+            this.metroComboBox4 = new MetroFramework.Controls.MetroComboBox();
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.metroComboBox3 = new MetroFramework.Controls.MetroComboBox();
             this.metroDateTime2 = new MetroFramework.Controls.MetroDateTime();
             this.metroLabel20 = new MetroFramework.Controls.MetroLabel();
             this.metroDateTime1 = new MetroFramework.Controls.MetroDateTime();
@@ -150,10 +155,11 @@
             this.metroTabControl1.Controls.Add(this.metroTabPage7);
             this.metroTabControl1.Controls.Add(this.metroTabPage5);
             this.metroTabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.metroTabControl1.Location = new System.Drawing.Point(20, 60);
+            this.metroTabControl1.Location = new System.Drawing.Point(27, 74);
+            this.metroTabControl1.Margin = new System.Windows.Forms.Padding(4);
             this.metroTabControl1.Name = "metroTabControl1";
-            this.metroTabControl1.SelectedIndex = 0;
-            this.metroTabControl1.Size = new System.Drawing.Size(680, 302);
+            this.metroTabControl1.SelectedIndex = 1;
+            this.metroTabControl1.Size = new System.Drawing.Size(906, 371);
             this.metroTabControl1.TabIndex = 0;
             this.metroTabControl1.UseSelectable = true;
             // 
@@ -183,25 +189,27 @@
             this.metroTabPage1.HorizontalScrollbar = true;
             this.metroTabPage1.HorizontalScrollbarBarColor = true;
             this.metroTabPage1.HorizontalScrollbarHighlightOnWheel = false;
-            this.metroTabPage1.HorizontalScrollbarSize = 10;
+            this.metroTabPage1.HorizontalScrollbarSize = 12;
             this.metroTabPage1.Location = new System.Drawing.Point(4, 38);
+            this.metroTabPage1.Margin = new System.Windows.Forms.Padding(4);
             this.metroTabPage1.Name = "metroTabPage1";
-            this.metroTabPage1.Padding = new System.Windows.Forms.Padding(25);
-            this.metroTabPage1.Size = new System.Drawing.Size(672, 260);
+            this.metroTabPage1.Padding = new System.Windows.Forms.Padding(33, 31, 33, 31);
+            this.metroTabPage1.Size = new System.Drawing.Size(898, 329);
             this.metroTabPage1.TabIndex = 0;
             this.metroTabPage1.Text = "Tiles && Buttons";
             this.metroTabPage1.VerticalScrollbar = true;
             this.metroTabPage1.VerticalScrollbarBarColor = true;
             this.metroTabPage1.VerticalScrollbarHighlightOnWheel = false;
-            this.metroTabPage1.VerticalScrollbarSize = 10;
+            this.metroTabPage1.VerticalScrollbarSize = 13;
             // 
             // metroRadioButton4
             // 
             this.metroRadioButton4.AutoSize = true;
             this.metroRadioButton4.Enabled = false;
-            this.metroRadioButton4.Location = new System.Drawing.Point(496, 205);
+            this.metroRadioButton4.Location = new System.Drawing.Point(661, 252);
+            this.metroRadioButton4.Margin = new System.Windows.Forms.Padding(4);
             this.metroRadioButton4.Name = "metroRadioButton4";
-            this.metroRadioButton4.Size = new System.Drawing.Size(137, 15);
+            this.metroRadioButton4.Size = new System.Drawing.Size(151, 17);
             this.metroRadioButton4.TabIndex = 23;
             this.metroRadioButton4.TabStop = true;
             this.metroRadioButton4.Text = "Disabled Radiobutton";
@@ -210,9 +218,10 @@
             // metroRadioButton5
             // 
             this.metroRadioButton5.AutoSize = true;
-            this.metroRadioButton5.Location = new System.Drawing.Point(496, 184);
+            this.metroRadioButton5.Location = new System.Drawing.Point(661, 226);
+            this.metroRadioButton5.Margin = new System.Windows.Forms.Padding(4);
             this.metroRadioButton5.Name = "metroRadioButton5";
-            this.metroRadioButton5.Size = new System.Drawing.Size(124, 15);
+            this.metroRadioButton5.Size = new System.Drawing.Size(135, 17);
             this.metroRadioButton5.TabIndex = 22;
             this.metroRadioButton5.TabStop = true;
             this.metroRadioButton5.Text = "Styled Radiobutton";
@@ -223,9 +232,10 @@
             // 
             this.metroCheckBox4.AutoSize = true;
             this.metroCheckBox4.Enabled = false;
-            this.metroCheckBox4.Location = new System.Drawing.Point(496, 98);
+            this.metroCheckBox4.Location = new System.Drawing.Point(661, 121);
+            this.metroCheckBox4.Margin = new System.Windows.Forms.Padding(4);
             this.metroCheckBox4.Name = "metroCheckBox4";
-            this.metroCheckBox4.Size = new System.Drawing.Size(123, 15);
+            this.metroCheckBox4.Size = new System.Drawing.Size(135, 17);
             this.metroCheckBox4.TabIndex = 21;
             this.metroCheckBox4.Text = "Disabled Checkbox";
             this.metroCheckBox4.UseSelectable = true;
@@ -233,9 +243,10 @@
             // metroCheckBox5
             // 
             this.metroCheckBox5.AutoSize = true;
-            this.metroCheckBox5.Location = new System.Drawing.Point(496, 77);
+            this.metroCheckBox5.Location = new System.Drawing.Point(661, 95);
+            this.metroCheckBox5.Margin = new System.Windows.Forms.Padding(4);
             this.metroCheckBox5.Name = "metroCheckBox5";
-            this.metroCheckBox5.Size = new System.Drawing.Size(110, 15);
+            this.metroCheckBox5.Size = new System.Drawing.Size(119, 17);
             this.metroCheckBox5.TabIndex = 20;
             this.metroCheckBox5.Text = "Styled Checkbox";
             this.metroCheckBox5.UseSelectable = true;
@@ -244,27 +255,30 @@
             // metroLabel21
             // 
             this.metroLabel21.AutoSize = true;
-            this.metroLabel21.Location = new System.Drawing.Point(496, 136);
+            this.metroLabel21.Location = new System.Drawing.Point(661, 167);
+            this.metroLabel21.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel21.Name = "metroLabel21";
-            this.metroLabel21.Size = new System.Drawing.Size(117, 19);
+            this.metroLabel21.Size = new System.Drawing.Size(120, 20);
             this.metroLabel21.TabIndex = 19;
             this.metroLabel21.Text = "MetroRadioButton";
             // 
             // metroLabel22
             // 
             this.metroLabel22.AutoSize = true;
-            this.metroLabel22.Location = new System.Drawing.Point(496, 28);
+            this.metroLabel22.Location = new System.Drawing.Point(661, 34);
+            this.metroLabel22.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel22.Name = "metroLabel22";
-            this.metroLabel22.Size = new System.Drawing.Size(102, 19);
+            this.metroLabel22.Size = new System.Drawing.Size(107, 20);
             this.metroLabel22.TabIndex = 18;
             this.metroLabel22.Text = "MetroCheckBox";
             // 
             // metroRadioButton6
             // 
             this.metroRadioButton6.AutoSize = true;
-            this.metroRadioButton6.Location = new System.Drawing.Point(496, 163);
+            this.metroRadioButton6.Location = new System.Drawing.Point(661, 201);
+            this.metroRadioButton6.Margin = new System.Windows.Forms.Padding(4);
             this.metroRadioButton6.Name = "metroRadioButton6";
-            this.metroRadioButton6.Size = new System.Drawing.Size(132, 15);
+            this.metroRadioButton6.Size = new System.Drawing.Size(144, 17);
             this.metroRadioButton6.TabIndex = 17;
             this.metroRadioButton6.TabStop = true;
             this.metroRadioButton6.Text = "Normal Radiobutton";
@@ -274,9 +288,10 @@
             // metroCheckBox6
             // 
             this.metroCheckBox6.AutoSize = true;
-            this.metroCheckBox6.Location = new System.Drawing.Point(496, 56);
+            this.metroCheckBox6.Location = new System.Drawing.Point(661, 69);
+            this.metroCheckBox6.Margin = new System.Windows.Forms.Padding(4);
             this.metroCheckBox6.Name = "metroCheckBox6";
-            this.metroCheckBox6.Size = new System.Drawing.Size(118, 15);
+            this.metroCheckBox6.Size = new System.Drawing.Size(128, 17);
             this.metroCheckBox6.TabIndex = 16;
             this.metroCheckBox6.Text = "Normal Checkbox";
             this.metroToolTip.SetToolTip(this.metroCheckBox6, "Checkbox Tooltip");
@@ -285,9 +300,10 @@
             // metroLink4
             // 
             this.metroLink4.Enabled = false;
-            this.metroLink4.Location = new System.Drawing.Point(368, 127);
+            this.metroLink4.Location = new System.Drawing.Point(491, 156);
+            this.metroLink4.Margin = new System.Windows.Forms.Padding(4);
             this.metroLink4.Name = "metroLink4";
-            this.metroLink4.Size = new System.Drawing.Size(95, 23);
+            this.metroLink4.Size = new System.Drawing.Size(127, 28);
             this.metroLink4.TabIndex = 15;
             this.metroLink4.Text = "Disabled Link";
             this.metroLink4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -295,9 +311,10 @@
             // 
             // metroLink3
             // 
-            this.metroLink3.Location = new System.Drawing.Point(368, 98);
+            this.metroLink3.Location = new System.Drawing.Point(491, 121);
+            this.metroLink3.Margin = new System.Windows.Forms.Padding(4);
             this.metroLink3.Name = "metroLink3";
-            this.metroLink3.Size = new System.Drawing.Size(95, 23);
+            this.metroLink3.Size = new System.Drawing.Size(127, 28);
             this.metroLink3.TabIndex = 14;
             this.metroLink3.Text = "Styled Link";
             this.metroLink3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -307,26 +324,29 @@
             // metroLabel9
             // 
             this.metroLabel9.AutoSize = true;
-            this.metroLabel9.Location = new System.Drawing.Point(368, 47);
+            this.metroLabel9.Location = new System.Drawing.Point(491, 58);
+            this.metroLabel9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel9.Name = "metroLabel9";
-            this.metroLabel9.Size = new System.Drawing.Size(67, 19);
+            this.metroLabel9.Size = new System.Drawing.Size(71, 20);
             this.metroLabel9.TabIndex = 12;
             this.metroLabel9.Text = "MetroLink";
             // 
             // metroLabel8
             // 
             this.metroLabel8.AutoSize = true;
-            this.metroLabel8.Location = new System.Drawing.Point(209, 25);
+            this.metroLabel8.Location = new System.Drawing.Point(279, 31);
+            this.metroLabel8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel8.Name = "metroLabel8";
-            this.metroLabel8.Size = new System.Drawing.Size(83, 19);
+            this.metroLabel8.Size = new System.Drawing.Size(86, 20);
             this.metroLabel8.TabIndex = 11;
             this.metroLabel8.Text = "MetroButton";
             // 
             // metroLink1
             // 
-            this.metroLink1.Location = new System.Drawing.Point(368, 69);
+            this.metroLink1.Location = new System.Drawing.Point(491, 85);
+            this.metroLink1.Margin = new System.Windows.Forms.Padding(4);
             this.metroLink1.Name = "metroLink1";
-            this.metroLink1.Size = new System.Drawing.Size(95, 23);
+            this.metroLink1.Size = new System.Drawing.Size(127, 28);
             this.metroLink1.TabIndex = 10;
             this.metroLink1.Text = "Normal Link";
             this.metroLink1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -336,18 +356,20 @@
             // metroLabel1
             // 
             this.metroLabel1.AutoSize = true;
-            this.metroLabel1.Location = new System.Drawing.Point(28, 25);
+            this.metroLabel1.Location = new System.Drawing.Point(37, 31);
+            this.metroLabel1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel1.Name = "metroLabel1";
-            this.metroLabel1.Size = new System.Drawing.Size(65, 19);
+            this.metroLabel1.Size = new System.Drawing.Size(68, 20);
             this.metroLabel1.TabIndex = 8;
             this.metroLabel1.Text = "MetroTile";
             // 
             // metroButton3
             // 
             this.metroButton3.Enabled = false;
-            this.metroButton3.Location = new System.Drawing.Point(209, 133);
+            this.metroButton3.Location = new System.Drawing.Point(279, 164);
+            this.metroButton3.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton3.Name = "metroButton3";
-            this.metroButton3.Size = new System.Drawing.Size(127, 37);
+            this.metroButton3.Size = new System.Drawing.Size(169, 46);
             this.metroButton3.TabIndex = 7;
             this.metroButton3.Text = "Disabled Button";
             this.metroButton3.UseSelectable = true;
@@ -355,9 +377,10 @@
             // metroButton2
             // 
             this.metroButton2.Highlight = true;
-            this.metroButton2.Location = new System.Drawing.Point(209, 90);
+            this.metroButton2.Location = new System.Drawing.Point(279, 111);
+            this.metroButton2.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton2.Name = "metroButton2";
-            this.metroButton2.Size = new System.Drawing.Size(127, 37);
+            this.metroButton2.Size = new System.Drawing.Size(169, 46);
             this.metroButton2.TabIndex = 6;
             this.metroButton2.Text = "Highlighted Button";
             this.metroButton2.UseSelectable = true;
@@ -366,9 +389,10 @@
             // metroButton1
             // 
             this.metroButton1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.metroButton1.Location = new System.Drawing.Point(209, 47);
+            this.metroButton1.Location = new System.Drawing.Point(279, 58);
+            this.metroButton1.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton1.Name = "metroButton1";
-            this.metroButton1.Size = new System.Drawing.Size(127, 37);
+            this.metroButton1.Size = new System.Drawing.Size(169, 46);
             this.metroButton1.TabIndex = 5;
             this.metroButton1.Text = "Normal Button";
             this.metroToolTip.SetToolTip(this.metroButton1, "Button Tooltip");
@@ -378,9 +402,10 @@
             // metroTileSwitch
             // 
             this.metroTileSwitch.ActiveControl = null;
-            this.metroTileSwitch.Location = new System.Drawing.Point(28, 133);
+            this.metroTileSwitch.Location = new System.Drawing.Point(37, 164);
+            this.metroTileSwitch.Margin = new System.Windows.Forms.Padding(4);
             this.metroTileSwitch.Name = "metroTileSwitch";
-            this.metroTileSwitch.Size = new System.Drawing.Size(166, 80);
+            this.metroTileSwitch.Size = new System.Drawing.Size(221, 98);
             this.metroTileSwitch.TabIndex = 4;
             this.metroTileSwitch.Text = "Switch Style";
             this.metroTileSwitch.UseSelectable = true;
@@ -390,9 +415,10 @@
             // 
             this.metroTile2.ActiveControl = null;
             this.metroTile2.Enabled = false;
-            this.metroTile2.Location = new System.Drawing.Point(114, 47);
+            this.metroTile2.Location = new System.Drawing.Point(152, 58);
+            this.metroTile2.Margin = new System.Windows.Forms.Padding(4);
             this.metroTile2.Name = "metroTile2";
-            this.metroTile2.Size = new System.Drawing.Size(80, 80);
+            this.metroTile2.Size = new System.Drawing.Size(107, 98);
             this.metroTile2.TabIndex = 3;
             this.metroTile2.Text = "Disabled";
             this.metroTile2.UseSelectable = true;
@@ -400,9 +426,10 @@
             // metroTile1
             // 
             this.metroTile1.ActiveControl = null;
-            this.metroTile1.Location = new System.Drawing.Point(28, 47);
+            this.metroTile1.Location = new System.Drawing.Point(37, 58);
+            this.metroTile1.Margin = new System.Windows.Forms.Padding(4);
             this.metroTile1.Name = "metroTile1";
-            this.metroTile1.Size = new System.Drawing.Size(80, 80);
+            this.metroTile1.Size = new System.Drawing.Size(107, 98);
             this.metroTile1.TabIndex = 2;
             this.metroTile1.Text = "Switch Theme";
             this.metroToolTip.SetToolTip(this.metroTile1, "Tile Tooltip");
@@ -411,6 +438,9 @@
             // 
             // metroTabPage2
             // 
+            this.metroTabPage2.Controls.Add(this.metroComboBox4);
+            this.metroTabPage2.Controls.Add(this.textBox1);
+            this.metroTabPage2.Controls.Add(this.metroComboBox3);
             this.metroTabPage2.Controls.Add(this.metroDateTime2);
             this.metroTabPage2.Controls.Add(this.metroLabel20);
             this.metroTabPage2.Controls.Add(this.metroDateTime1);
@@ -432,49 +462,101 @@
             this.metroTabPage2.Controls.Add(this.metroCheckBox1);
             this.metroTabPage2.HorizontalScrollbarBarColor = true;
             this.metroTabPage2.HorizontalScrollbarHighlightOnWheel = false;
-            this.metroTabPage2.HorizontalScrollbarSize = 10;
+            this.metroTabPage2.HorizontalScrollbarSize = 12;
             this.metroTabPage2.Location = new System.Drawing.Point(4, 38);
+            this.metroTabPage2.Margin = new System.Windows.Forms.Padding(4);
             this.metroTabPage2.Name = "metroTabPage2";
-            this.metroTabPage2.Padding = new System.Windows.Forms.Padding(25);
-            this.metroTabPage2.Size = new System.Drawing.Size(672, 260);
+            this.metroTabPage2.Padding = new System.Windows.Forms.Padding(33, 31, 33, 31);
+            this.metroTabPage2.Size = new System.Drawing.Size(898, 329);
             this.metroTabPage2.TabIndex = 1;
             this.metroTabPage2.Text = "Options";
             this.metroTabPage2.VerticalScrollbarBarColor = true;
             this.metroTabPage2.VerticalScrollbarHighlightOnWheel = false;
-            this.metroTabPage2.VerticalScrollbarSize = 10;
+            this.metroTabPage2.VerticalScrollbarSize = 13;
             this.metroTabPage2.Visible = false;
+            // 
+            // metroComboBox4
+            // 
+            this.metroComboBox4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.metroComboBox4.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.metroComboBox4.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
+            this.metroComboBox4.FormattingEnabled = true;
+            this.metroComboBox4.ItemHeight = 24;
+            this.metroComboBox4.Location = new System.Drawing.Point(268, 295);
+            this.metroComboBox4.Margin = new System.Windows.Forms.Padding(4);
+            this.metroComboBox4.Name = "metroComboBox4";
+            this.metroComboBox4.PromptText = "DataBound ComboBox";
+            this.metroComboBox4.Size = new System.Drawing.Size(283, 30);
+            this.metroComboBox4.TabIndex = 23;
+            this.metroToolTip.SetToolTip(this.metroComboBox4, "ComboBox Tooltip");
+            this.metroComboBox4.UseSelectable = true;
+            // 
+            // textBox1
+            // 
+            this.textBox1.Location = new System.Drawing.Point(604, 291);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(258, 22);
+            this.textBox1.TabIndex = 22;
+            // 
+            // metroComboBox3
+            // 
+            this.metroComboBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.metroComboBox3.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.metroComboBox3.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
+            this.metroComboBox3.FormattingEnabled = true;
+            this.metroComboBox3.ItemHeight = 24;
+            this.metroComboBox3.Items.AddRange(new object[] {
+            "Normal Combobox 1",
+            "Normal Combobox 2",
+            "Normal Combobox 3",
+            "Normal Combobox 4"});
+            this.metroComboBox3.Location = new System.Drawing.Point(268, 260);
+            this.metroComboBox3.Margin = new System.Windows.Forms.Padding(4);
+            this.metroComboBox3.Name = "metroComboBox3";
+            this.metroComboBox3.PromptText = "Prompted ComboBox";
+            this.metroComboBox3.Size = new System.Drawing.Size(283, 30);
+            this.metroComboBox3.TabIndex = 21;
+            this.metroToolTip.SetToolTip(this.metroComboBox3, "ComboBox Tooltip");
+            this.metroComboBox3.UseSelectable = true;
+            this.metroComboBox3.TextChanged += new System.EventHandler(this.metroComboBox3_TextChanged);
             // 
             // metroDateTime2
             // 
             this.metroDateTime2.Enabled = false;
-            this.metroDateTime2.Location = new System.Drawing.Point(201, 87);
-            this.metroDateTime2.MinimumSize = new System.Drawing.Size(4, 29);
+            this.metroDateTime2.Location = new System.Drawing.Point(268, 107);
+            this.metroDateTime2.Margin = new System.Windows.Forms.Padding(4);
+            this.metroDateTime2.MinimumSize = new System.Drawing.Size(0, 30);
             this.metroDateTime2.Name = "metroDateTime2";
-            this.metroDateTime2.Size = new System.Drawing.Size(213, 29);
+            this.metroDateTime2.Size = new System.Drawing.Size(283, 30);
             this.metroDateTime2.TabIndex = 20;
             // 
             // metroLabel20
             // 
             this.metroLabel20.AutoSize = true;
-            this.metroLabel20.Location = new System.Drawing.Point(201, 25);
+            this.metroLabel20.Location = new System.Drawing.Point(268, 31);
+            this.metroLabel20.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel20.Name = "metroLabel20";
-            this.metroLabel20.Size = new System.Drawing.Size(101, 19);
+            this.metroLabel20.Size = new System.Drawing.Size(106, 20);
             this.metroLabel20.TabIndex = 19;
             this.metroLabel20.Text = "MetroDateTime";
             // 
             // metroDateTime1
             // 
-            this.metroDateTime1.Location = new System.Drawing.Point(201, 51);
-            this.metroDateTime1.MinimumSize = new System.Drawing.Size(4, 29);
+            this.metroDateTime1.Location = new System.Drawing.Point(268, 63);
+            this.metroDateTime1.Margin = new System.Windows.Forms.Padding(4);
+            this.metroDateTime1.MinimumSize = new System.Drawing.Size(0, 30);
             this.metroDateTime1.Name = "metroDateTime1";
-            this.metroDateTime1.Size = new System.Drawing.Size(213, 29);
+            this.metroDateTime1.Size = new System.Drawing.Size(283, 30);
             this.metroDateTime1.TabIndex = 18;
             // 
             // metroButton5
             // 
-            this.metroButton5.Location = new System.Drawing.Point(453, 51);
+            this.metroButton5.Location = new System.Drawing.Point(604, 63);
+            this.metroButton5.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton5.Name = "metroButton5";
-            this.metroButton5.Size = new System.Drawing.Size(123, 29);
+            this.metroButton5.Size = new System.Drawing.Size(164, 36);
             this.metroButton5.TabIndex = 17;
             this.metroButton5.Text = "&Show Context Menu";
             this.metroButton5.UseSelectable = true;
@@ -482,14 +564,14 @@
             // 
             // metroComboBox2
             // 
+            this.metroComboBox2.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDown;
             this.metroComboBox2.Enabled = false;
             this.metroComboBox2.FormattingEnabled = true;
-            this.metroComboBox2.ItemHeight = 23;
-            this.metroComboBox2.Items.AddRange(new object[] {
-            "Normal Combobox"});
-            this.metroComboBox2.Location = new System.Drawing.Point(201, 200);
+            this.metroComboBox2.ItemHeight = 24;
+            this.metroComboBox2.Location = new System.Drawing.Point(268, 222);
+            this.metroComboBox2.Margin = new System.Windows.Forms.Padding(4);
             this.metroComboBox2.Name = "metroComboBox2";
-            this.metroComboBox2.Size = new System.Drawing.Size(213, 29);
+            this.metroComboBox2.Size = new System.Drawing.Size(283, 30);
             this.metroComboBox2.TabIndex = 16;
             this.metroComboBox2.UseSelectable = true;
             // 
@@ -498,9 +580,10 @@
             this.metroToggle3.AutoSize = true;
             this.metroToggle3.DisplayStatus = false;
             this.metroToggle3.Enabled = false;
-            this.metroToggle3.Location = new System.Drawing.Point(483, 212);
+            this.metroToggle3.Location = new System.Drawing.Point(644, 261);
+            this.metroToggle3.Margin = new System.Windows.Forms.Padding(4);
             this.metroToggle3.Name = "metroToggle3";
-            this.metroToggle3.Size = new System.Drawing.Size(50, 17);
+            this.metroToggle3.Size = new System.Drawing.Size(50, 21);
             this.metroToggle3.TabIndex = 15;
             this.metroToggle3.Text = "Off";
             this.metroToggle3.UseSelectable = true;
@@ -509,9 +592,10 @@
             // 
             this.metroToggle2.AutoSize = true;
             this.metroToggle2.DisplayStatus = false;
-            this.metroToggle2.Location = new System.Drawing.Point(483, 189);
+            this.metroToggle2.Location = new System.Drawing.Point(644, 233);
+            this.metroToggle2.Margin = new System.Windows.Forms.Padding(4);
             this.metroToggle2.Name = "metroToggle2";
-            this.metroToggle2.Size = new System.Drawing.Size(50, 17);
+            this.metroToggle2.Size = new System.Drawing.Size(50, 21);
             this.metroToggle2.TabIndex = 14;
             this.metroToggle2.Text = "Off";
             this.metroToggle2.UseSelectable = true;
@@ -521,9 +605,10 @@
             // 
             this.metroRadioButton3.AutoSize = true;
             this.metroRadioButton3.Enabled = false;
-            this.metroRadioButton3.Location = new System.Drawing.Point(18, 202);
+            this.metroRadioButton3.Location = new System.Drawing.Point(24, 249);
+            this.metroRadioButton3.Margin = new System.Windows.Forms.Padding(4);
             this.metroRadioButton3.Name = "metroRadioButton3";
-            this.metroRadioButton3.Size = new System.Drawing.Size(137, 15);
+            this.metroRadioButton3.Size = new System.Drawing.Size(151, 17);
             this.metroRadioButton3.TabIndex = 13;
             this.metroRadioButton3.TabStop = true;
             this.metroRadioButton3.Text = "Disabled Radiobutton";
@@ -532,9 +617,10 @@
             // metroRadioButton2
             // 
             this.metroRadioButton2.AutoSize = true;
-            this.metroRadioButton2.Location = new System.Drawing.Point(18, 181);
+            this.metroRadioButton2.Location = new System.Drawing.Point(24, 223);
+            this.metroRadioButton2.Margin = new System.Windows.Forms.Padding(4);
             this.metroRadioButton2.Name = "metroRadioButton2";
-            this.metroRadioButton2.Size = new System.Drawing.Size(124, 15);
+            this.metroRadioButton2.Size = new System.Drawing.Size(135, 17);
             this.metroRadioButton2.TabIndex = 12;
             this.metroRadioButton2.TabStop = true;
             this.metroRadioButton2.Text = "Styled Radiobutton";
@@ -545,9 +631,10 @@
             // 
             this.metroCheckBox3.AutoSize = true;
             this.metroCheckBox3.Enabled = false;
-            this.metroCheckBox3.Location = new System.Drawing.Point(18, 95);
+            this.metroCheckBox3.Location = new System.Drawing.Point(24, 117);
+            this.metroCheckBox3.Margin = new System.Windows.Forms.Padding(4);
             this.metroCheckBox3.Name = "metroCheckBox3";
-            this.metroCheckBox3.Size = new System.Drawing.Size(123, 15);
+            this.metroCheckBox3.Size = new System.Drawing.Size(135, 17);
             this.metroCheckBox3.TabIndex = 11;
             this.metroCheckBox3.Text = "Disabled Checkbox";
             this.metroCheckBox3.UseSelectable = true;
@@ -555,9 +642,10 @@
             // metroCheckBox2
             // 
             this.metroCheckBox2.AutoSize = true;
-            this.metroCheckBox2.Location = new System.Drawing.Point(18, 74);
+            this.metroCheckBox2.Location = new System.Drawing.Point(24, 91);
+            this.metroCheckBox2.Margin = new System.Windows.Forms.Padding(4);
             this.metroCheckBox2.Name = "metroCheckBox2";
-            this.metroCheckBox2.Size = new System.Drawing.Size(110, 15);
+            this.metroCheckBox2.Size = new System.Drawing.Size(119, 17);
             this.metroCheckBox2.TabIndex = 10;
             this.metroCheckBox2.Text = "Styled Checkbox";
             this.metroCheckBox2.UseSelectable = true;
@@ -566,52 +654,57 @@
             // metroLabel19
             // 
             this.metroLabel19.AutoSize = true;
-            this.metroLabel19.Location = new System.Drawing.Point(453, 139);
+            this.metroLabel19.Location = new System.Drawing.Point(604, 171);
+            this.metroLabel19.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel19.Name = "metroLabel19";
-            this.metroLabel19.Size = new System.Drawing.Size(84, 19);
+            this.metroLabel19.Size = new System.Drawing.Size(89, 20);
             this.metroLabel19.TabIndex = 9;
             this.metroLabel19.Text = "MetroToggle";
             // 
             // metroLabel18
             // 
             this.metroLabel18.AutoSize = true;
-            this.metroLabel18.Location = new System.Drawing.Point(18, 133);
+            this.metroLabel18.Location = new System.Drawing.Point(24, 164);
+            this.metroLabel18.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel18.Name = "metroLabel18";
-            this.metroLabel18.Size = new System.Drawing.Size(117, 19);
+            this.metroLabel18.Size = new System.Drawing.Size(120, 20);
             this.metroLabel18.TabIndex = 8;
             this.metroLabel18.Text = "MetroRadioButton";
             // 
             // metroLabel17
             // 
             this.metroLabel17.AutoSize = true;
-            this.metroLabel17.Location = new System.Drawing.Point(201, 143);
+            this.metroLabel17.Location = new System.Drawing.Point(268, 152);
+            this.metroLabel17.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel17.Name = "metroLabel17";
-            this.metroLabel17.Size = new System.Drawing.Size(112, 19);
+            this.metroLabel17.Size = new System.Drawing.Size(113, 20);
             this.metroLabel17.TabIndex = 7;
             this.metroLabel17.Text = "MetroComboBox";
             // 
             // metroLabel16
             // 
             this.metroLabel16.AutoSize = true;
-            this.metroLabel16.Location = new System.Drawing.Point(18, 25);
+            this.metroLabel16.Location = new System.Drawing.Point(24, 31);
+            this.metroLabel16.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel16.Name = "metroLabel16";
-            this.metroLabel16.Size = new System.Drawing.Size(102, 19);
+            this.metroLabel16.Size = new System.Drawing.Size(107, 20);
             this.metroLabel16.TabIndex = 6;
             this.metroLabel16.Text = "MetroCheckBox";
             // 
             // metroComboBox1
             // 
             this.metroComboBox1.FormattingEnabled = true;
-            this.metroComboBox1.ItemHeight = 23;
+            this.metroComboBox1.ItemHeight = 24;
             this.metroComboBox1.Items.AddRange(new object[] {
-            "Normal Combobox 1",
+            "Normal Combobox 1Normal Combobox 1Normal Combobox 1",
             "Normal Combobox 2",
             "Normal Combobox 3",
             "Normal Combobox 4"});
-            this.metroComboBox1.Location = new System.Drawing.Point(201, 165);
+            this.metroComboBox1.Location = new System.Drawing.Point(268, 179);
+            this.metroComboBox1.Margin = new System.Windows.Forms.Padding(4);
             this.metroComboBox1.Name = "metroComboBox1";
             this.metroComboBox1.PromptText = "Prompted ComboBox";
-            this.metroComboBox1.Size = new System.Drawing.Size(213, 29);
+            this.metroComboBox1.Size = new System.Drawing.Size(283, 30);
             this.metroComboBox1.TabIndex = 5;
             this.metroToolTip.SetToolTip(this.metroComboBox1, "ComboBox Tooltip");
             this.metroComboBox1.UseSelectable = true;
@@ -619,9 +712,10 @@
             // metroRadioButton1
             // 
             this.metroRadioButton1.AutoSize = true;
-            this.metroRadioButton1.Location = new System.Drawing.Point(18, 160);
+            this.metroRadioButton1.Location = new System.Drawing.Point(24, 197);
+            this.metroRadioButton1.Margin = new System.Windows.Forms.Padding(4);
             this.metroRadioButton1.Name = "metroRadioButton1";
-            this.metroRadioButton1.Size = new System.Drawing.Size(132, 15);
+            this.metroRadioButton1.Size = new System.Drawing.Size(144, 17);
             this.metroRadioButton1.TabIndex = 4;
             this.metroRadioButton1.TabStop = true;
             this.metroRadioButton1.Text = "Normal Radiobutton";
@@ -631,9 +725,10 @@
             // metroToggle1
             // 
             this.metroToggle1.AutoSize = true;
-            this.metroToggle1.Location = new System.Drawing.Point(453, 166);
+            this.metroToggle1.Location = new System.Drawing.Point(604, 204);
+            this.metroToggle1.Margin = new System.Windows.Forms.Padding(4);
             this.metroToggle1.Name = "metroToggle1";
-            this.metroToggle1.Size = new System.Drawing.Size(80, 17);
+            this.metroToggle1.Size = new System.Drawing.Size(80, 21);
             this.metroToggle1.TabIndex = 3;
             this.metroToggle1.Text = "Off";
             this.metroToolTip.SetToolTip(this.metroToggle1, "Toggle Tooltip");
@@ -642,9 +737,10 @@
             // metroCheckBox1
             // 
             this.metroCheckBox1.AutoSize = true;
-            this.metroCheckBox1.Location = new System.Drawing.Point(18, 53);
+            this.metroCheckBox1.Location = new System.Drawing.Point(24, 65);
+            this.metroCheckBox1.Margin = new System.Windows.Forms.Padding(4);
             this.metroCheckBox1.Name = "metroCheckBox1";
-            this.metroCheckBox1.Size = new System.Drawing.Size(118, 15);
+            this.metroCheckBox1.Size = new System.Drawing.Size(128, 17);
             this.metroCheckBox1.TabIndex = 2;
             this.metroCheckBox1.Text = "Normal Checkbox";
             this.metroToolTip.SetToolTip(this.metroCheckBox1, "Checkbox Tooltip");
@@ -666,44 +762,48 @@
             this.metroTabPage3.HorizontalScrollbar = true;
             this.metroTabPage3.HorizontalScrollbarBarColor = true;
             this.metroTabPage3.HorizontalScrollbarHighlightOnWheel = false;
-            this.metroTabPage3.HorizontalScrollbarSize = 10;
+            this.metroTabPage3.HorizontalScrollbarSize = 12;
             this.metroTabPage3.Location = new System.Drawing.Point(4, 38);
+            this.metroTabPage3.Margin = new System.Windows.Forms.Padding(4);
             this.metroTabPage3.Name = "metroTabPage3";
-            this.metroTabPage3.Padding = new System.Windows.Forms.Padding(25);
-            this.metroTabPage3.Size = new System.Drawing.Size(672, 260);
+            this.metroTabPage3.Padding = new System.Windows.Forms.Padding(33, 31, 33, 31);
+            this.metroTabPage3.Size = new System.Drawing.Size(898, 329);
             this.metroTabPage3.TabIndex = 2;
             this.metroTabPage3.Text = "Scroll && Progress";
             this.metroTabPage3.VerticalScrollbar = true;
             this.metroTabPage3.VerticalScrollbarBarColor = true;
             this.metroTabPage3.VerticalScrollbarHighlightOnWheel = false;
-            this.metroTabPage3.VerticalScrollbarSize = 10;
+            this.metroTabPage3.VerticalScrollbarSize = 13;
             this.metroTabPage3.Visible = false;
             // 
             // metroLabel7
             // 
             this.metroLabel7.AutoSize = true;
-            this.metroLabel7.Location = new System.Drawing.Point(28, 187);
+            this.metroLabel7.Location = new System.Drawing.Point(37, 230);
+            this.metroLabel7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel7.Name = "metroLabel7";
-            this.metroLabel7.Size = new System.Drawing.Size(97, 19);
+            this.metroLabel7.Size = new System.Drawing.Size(99, 20);
             this.metroLabel7.TabIndex = 12;
             this.metroLabel7.Text = "MetroScrollBar";
             // 
             // metroProgressSpinner3
             // 
-            this.metroProgressSpinner3.Location = new System.Drawing.Point(345, 146);
+            this.metroProgressSpinner3.Location = new System.Drawing.Point(460, 180);
+            this.metroProgressSpinner3.Margin = new System.Windows.Forms.Padding(4);
             this.metroProgressSpinner3.Maximum = 100;
             this.metroProgressSpinner3.Name = "metroProgressSpinner3";
-            this.metroProgressSpinner3.Size = new System.Drawing.Size(23, 23);
+            this.metroProgressSpinner3.Size = new System.Drawing.Size(31, 28);
             this.metroProgressSpinner3.TabIndex = 11;
             this.metroProgressSpinner3.UseSelectable = true;
             this.metroProgressSpinner3.Value = 50;
             // 
             // metroProgressSpinner2
             // 
-            this.metroProgressSpinner2.Location = new System.Drawing.Point(316, 146);
+            this.metroProgressSpinner2.Location = new System.Drawing.Point(421, 180);
+            this.metroProgressSpinner2.Margin = new System.Windows.Forms.Padding(4);
             this.metroProgressSpinner2.Maximum = 100;
             this.metroProgressSpinner2.Name = "metroProgressSpinner2";
-            this.metroProgressSpinner2.Size = new System.Drawing.Size(23, 23);
+            this.metroProgressSpinner2.Size = new System.Drawing.Size(31, 28);
             this.metroProgressSpinner2.TabIndex = 10;
             this.metroProgressSpinner2.UseSelectable = true;
             this.metroProgressSpinner2.Value = 25;
@@ -711,18 +811,20 @@
             // metroLabel6
             // 
             this.metroLabel6.AutoSize = true;
-            this.metroLabel6.Location = new System.Drawing.Point(287, 124);
+            this.metroLabel6.Location = new System.Drawing.Point(383, 153);
+            this.metroLabel6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel6.Name = "metroLabel6";
-            this.metroLabel6.Size = new System.Drawing.Size(140, 19);
+            this.metroLabel6.Size = new System.Drawing.Size(147, 20);
             this.metroLabel6.TabIndex = 9;
             this.metroLabel6.Text = "MetroProgressSpinner";
             // 
             // metroLabel5
             // 
             this.metroLabel5.AutoSize = true;
-            this.metroLabel5.Location = new System.Drawing.Point(28, 124);
+            this.metroLabel5.Location = new System.Drawing.Point(37, 153);
+            this.metroLabel5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel5.Name = "metroLabel5";
-            this.metroLabel5.Size = new System.Drawing.Size(94, 19);
+            this.metroLabel5.Size = new System.Drawing.Size(100, 20);
             this.metroLabel5.TabIndex = 8;
             this.metroLabel5.Text = "MetroTrackBar";
             // 
@@ -730,20 +832,22 @@
             // 
             this.metroProgressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.metroProgressBar1.Location = new System.Drawing.Point(28, 76);
-            this.metroProgressBar1.MinimumSize = new System.Drawing.Size(500, 23);
+            this.metroProgressBar1.Location = new System.Drawing.Point(37, 94);
+            this.metroProgressBar1.Margin = new System.Windows.Forms.Padding(4);
+            this.metroProgressBar1.MinimumSize = new System.Drawing.Size(667, 28);
             this.metroProgressBar1.Name = "metroProgressBar1";
             this.metroProgressBar1.ProgressBarStyle = System.Windows.Forms.ProgressBarStyle.Marquee;
-            this.metroProgressBar1.Size = new System.Drawing.Size(500, 23);
+            this.metroProgressBar1.Size = new System.Drawing.Size(667, 28);
             this.metroProgressBar1.TabIndex = 7;
             this.metroProgressBar1.Value = 25;
             // 
             // metroLabel4
             // 
             this.metroLabel4.AutoSize = true;
-            this.metroLabel4.Location = new System.Drawing.Point(28, 25);
+            this.metroLabel4.Location = new System.Drawing.Point(37, 31);
+            this.metroLabel4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.metroLabel4.Name = "metroLabel4";
-            this.metroLabel4.Size = new System.Drawing.Size(116, 19);
+            this.metroLabel4.Size = new System.Drawing.Size(120, 20);
             this.metroLabel4.TabIndex = 6;
             this.metroLabel4.Text = "MetroProgressBar";
             // 
@@ -752,15 +856,16 @@
             this.metroScrollBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.metroScrollBar1.LargeChange = 10;
-            this.metroScrollBar1.Location = new System.Drawing.Point(31, 209);
+            this.metroScrollBar1.Location = new System.Drawing.Point(41, 257);
+            this.metroScrollBar1.Margin = new System.Windows.Forms.Padding(4);
             this.metroScrollBar1.Maximum = 100;
             this.metroScrollBar1.Minimum = 0;
-            this.metroScrollBar1.MinimumSize = new System.Drawing.Size(500, 23);
+            this.metroScrollBar1.MinimumSize = new System.Drawing.Size(667, 28);
             this.metroScrollBar1.MouseWheelBarPartitions = 10;
             this.metroScrollBar1.Name = "metroScrollBar1";
             this.metroScrollBar1.Orientation = MetroFramework.Controls.MetroScrollOrientation.Horizontal;
-            this.metroScrollBar1.ScrollbarSize = 23;
-            this.metroScrollBar1.Size = new System.Drawing.Size(500, 23);
+            this.metroScrollBar1.ScrollbarSize = 28;
+            this.metroScrollBar1.Size = new System.Drawing.Size(667, 28);
             this.metroScrollBar1.TabIndex = 5;
             this.metroToolTip.SetToolTip(this.metroScrollBar1, "Scrollbar Tooltip");
             this.metroScrollBar1.UseBarColor = true;
@@ -769,19 +874,21 @@
             // metroTrackBar1
             // 
             this.metroTrackBar1.BackColor = System.Drawing.Color.Transparent;
-            this.metroTrackBar1.Location = new System.Drawing.Point(28, 146);
+            this.metroTrackBar1.Location = new System.Drawing.Point(37, 180);
+            this.metroTrackBar1.Margin = new System.Windows.Forms.Padding(4);
             this.metroTrackBar1.Name = "metroTrackBar1";
-            this.metroTrackBar1.Size = new System.Drawing.Size(237, 23);
+            this.metroTrackBar1.Size = new System.Drawing.Size(316, 28);
             this.metroTrackBar1.TabIndex = 4;
             this.metroTrackBar1.Text = "metroTrackBar1";
             this.metroToolTip.SetToolTip(this.metroTrackBar1, "TrackBar Tooltip");
             // 
             // metroProgressSpinner1
             // 
-            this.metroProgressSpinner1.Location = new System.Drawing.Point(287, 146);
+            this.metroProgressSpinner1.Location = new System.Drawing.Point(383, 180);
+            this.metroProgressSpinner1.Margin = new System.Windows.Forms.Padding(4);
             this.metroProgressSpinner1.Maximum = 100;
             this.metroProgressSpinner1.Name = "metroProgressSpinner1";
-            this.metroProgressSpinner1.Size = new System.Drawing.Size(23, 23);
+            this.metroProgressSpinner1.Size = new System.Drawing.Size(31, 28);
             this.metroProgressSpinner1.TabIndex = 3;
             this.metroToolTip.SetToolTip(this.metroProgressSpinner1, "Spinner Tooltip");
             this.metroProgressSpinner1.UseSelectable = true;
@@ -791,10 +898,11 @@
             this.metroProgressBar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.metroProgressBar.Enabled = false;
-            this.metroProgressBar.Location = new System.Drawing.Point(28, 47);
-            this.metroProgressBar.MinimumSize = new System.Drawing.Size(500, 23);
+            this.metroProgressBar.Location = new System.Drawing.Point(37, 58);
+            this.metroProgressBar.Margin = new System.Windows.Forms.Padding(4);
+            this.metroProgressBar.MinimumSize = new System.Drawing.Size(667, 28);
             this.metroProgressBar.Name = "metroProgressBar";
-            this.metroProgressBar.Size = new System.Drawing.Size(500, 23);
+            this.metroProgressBar.Size = new System.Drawing.Size(667, 28);
             this.metroProgressBar.TabIndex = 2;
             this.metroToolTip.SetToolTip(this.metroProgressBar, "ProgressBar Tooltip");
             this.metroProgressBar.Value = 25;
@@ -815,74 +923,132 @@
             this.metroTabPage4.Controls.Add(this.metroLabel2);
             this.metroTabPage4.HorizontalScrollbarBarColor = true;
             this.metroTabPage4.HorizontalScrollbarHighlightOnWheel = false;
-            this.metroTabPage4.HorizontalScrollbarSize = 10;
+            this.metroTabPage4.HorizontalScrollbarSize = 12;
             this.metroTabPage4.Location = new System.Drawing.Point(4, 38);
+            this.metroTabPage4.Margin = new System.Windows.Forms.Padding(4);
             this.metroTabPage4.Name = "metroTabPage4";
-            this.metroTabPage4.Padding = new System.Windows.Forms.Padding(25);
-            this.metroTabPage4.Size = new System.Drawing.Size(672, 260);
+            this.metroTabPage4.Padding = new System.Windows.Forms.Padding(33, 31, 33, 31);
+            this.metroTabPage4.Size = new System.Drawing.Size(898, 329);
             this.metroTabPage4.TabIndex = 3;
             this.metroTabPage4.Text = "Labels && Text";
             this.metroTabPage4.VerticalScrollbarBarColor = true;
             this.metroTabPage4.VerticalScrollbarHighlightOnWheel = false;
-            this.metroTabPage4.VerticalScrollbarSize = 10;
+            this.metroTabPage4.VerticalScrollbarSize = 13;
             this.metroTabPage4.Visible = false;
             // 
             // metroTextBox4
             // 
+            // 
+            // 
+            // 
+            this.metroTextBox4.CustomButton.Image = null;
+            this.metroTextBox4.CustomButton.Location = new System.Drawing.Point(202, 1);
+            this.metroTextBox4.CustomButton.Margin = new System.Windows.Forms.Padding(5);
+            this.metroTextBox4.CustomButton.Name = "";
+            this.metroTextBox4.CustomButton.Size = new System.Drawing.Size(25, 25);
+            this.metroTextBox4.CustomButton.Style = MetroFramework.MetroColorStyle.Blue;
+            this.metroTextBox4.CustomButton.TabIndex = 1;
+            this.metroTextBox4.CustomButton.Theme = MetroFramework.MetroThemeStyle.Light;
+            this.metroTextBox4.CustomButton.UseSelectable = true;
+            this.metroTextBox4.CustomButton.Visible = false;
             this.metroTextBox4.Enabled = false;
             this.metroTextBox4.Lines = new string[] {
         "Disabled Textbox"};
-            this.metroTextBox4.Location = new System.Drawing.Point(342, 106);
+            this.metroTextBox4.Location = new System.Drawing.Point(456, 130);
+            this.metroTextBox4.Margin = new System.Windows.Forms.Padding(4);
             this.metroTextBox4.MaxLength = 32767;
             this.metroTextBox4.Name = "metroTextBox4";
             this.metroTextBox4.PasswordChar = '\0';
             this.metroTextBox4.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.metroTextBox4.SelectedText = "";
-            this.metroTextBox4.Size = new System.Drawing.Size(171, 22);
+            this.metroTextBox4.SelectionLength = 0;
+            this.metroTextBox4.SelectionStart = 0;
+            this.metroTextBox4.ShortcutsEnabled = true;
+            this.metroTextBox4.Size = new System.Drawing.Size(228, 27);
             this.metroTextBox4.TabIndex = 13;
             this.metroTextBox4.Text = "Disabled Textbox";
             this.metroTextBox4.UseSelectable = true;
+            this.metroTextBox4.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
+            this.metroTextBox4.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
             // 
             // metroTextBox3
             // 
+            // 
+            // 
+            // 
+            this.metroTextBox3.CustomButton.Image = null;
+            this.metroTextBox3.CustomButton.Location = new System.Drawing.Point(118, 2);
+            this.metroTextBox3.CustomButton.Margin = new System.Windows.Forms.Padding(5);
+            this.metroTextBox3.CustomButton.Name = "";
+            this.metroTextBox3.CustomButton.Size = new System.Drawing.Size(107, 107);
+            this.metroTextBox3.CustomButton.Style = MetroFramework.MetroColorStyle.Blue;
+            this.metroTextBox3.CustomButton.TabIndex = 1;
+            this.metroTextBox3.CustomButton.Theme = MetroFramework.MetroThemeStyle.Light;
+            this.metroTextBox3.CustomButton.UseSelectable = true;
+            this.metroTextBox3.CustomButton.Visible = false;
             this.metroTextBox3.Lines = new string[] {
         "Multiline Textbox"};
-            this.metroTextBox3.Location = new System.Drawing.Point(342, 134);
+            this.metroTextBox3.Location = new System.Drawing.Point(456, 165);
+            this.metroTextBox3.Margin = new System.Windows.Forms.Padding(4);
             this.metroTextBox3.MaxLength = 32767;
             this.metroTextBox3.Multiline = true;
             this.metroTextBox3.Name = "metroTextBox3";
             this.metroTextBox3.PasswordChar = '\0';
             this.metroTextBox3.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.metroTextBox3.SelectedText = "";
-            this.metroTextBox3.Size = new System.Drawing.Size(171, 91);
+            this.metroTextBox3.SelectionLength = 0;
+            this.metroTextBox3.SelectionStart = 0;
+            this.metroTextBox3.ShortcutsEnabled = true;
+            this.metroTextBox3.Size = new System.Drawing.Size(228, 112);
             this.metroTextBox3.TabIndex = 12;
             this.metroTextBox3.Text = "Multiline Textbox";
             this.metroTextBox3.UseSelectable = true;
+            this.metroTextBox3.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
+            this.metroTextBox3.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
             // 
             // metroTextBox2
             // 
+            // 
+            // 
+            // 
+            this.metroTextBox2.CustomButton.Image = null;
+            this.metroTextBox2.CustomButton.Location = new System.Drawing.Point(202, 1);
+            this.metroTextBox2.CustomButton.Margin = new System.Windows.Forms.Padding(5);
+            this.metroTextBox2.CustomButton.Name = "";
+            this.metroTextBox2.CustomButton.Size = new System.Drawing.Size(25, 25);
+            this.metroTextBox2.CustomButton.Style = MetroFramework.MetroColorStyle.Blue;
+            this.metroTextBox2.CustomButton.TabIndex = 1;
+            this.metroTextBox2.CustomButton.Theme = MetroFramework.MetroThemeStyle.Light;
+            this.metroTextBox2.CustomButton.UseSelectable = true;
+            this.metroTextBox2.CustomButton.Visible = false;
             this.metroTextBox2.IconRight = true;
             this.metroTextBox2.Lines = new string[] {
         "Styled Textbox"};
-            this.metroTextBox2.Location = new System.Drawing.Point(342, 78);
+            this.metroTextBox2.Location = new System.Drawing.Point(456, 96);
+            this.metroTextBox2.Margin = new System.Windows.Forms.Padding(4);
             this.metroTextBox2.MaxLength = 32767;
             this.metroTextBox2.Name = "metroTextBox2";
             this.metroTextBox2.PasswordChar = '\0';
             this.metroTextBox2.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.metroTextBox2.SelectedText = "";
-            this.metroTextBox2.Size = new System.Drawing.Size(171, 22);
+            this.metroTextBox2.SelectionLength = 0;
+            this.metroTextBox2.SelectionStart = 0;
+            this.metroTextBox2.ShortcutsEnabled = true;
+            this.metroTextBox2.Size = new System.Drawing.Size(228, 27);
             this.metroTextBox2.TabIndex = 11;
             this.metroTextBox2.Text = "Styled Textbox";
             this.metroTextBox2.UseSelectable = true;
             this.metroTextBox2.UseStyleColors = true;
+            this.metroTextBox2.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
+            this.metroTextBox2.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
             // 
             // metroLabel15
             // 
             this.metroLabel15.AutoSize = true;
-            this.metroLabel15.Location = new System.Drawing.Point(342, 25);
-            this.metroLabel15.Margin = new System.Windows.Forms.Padding(3);
+            this.metroLabel15.Location = new System.Drawing.Point(456, 31);
+            this.metroLabel15.Margin = new System.Windows.Forms.Padding(4);
             this.metroLabel15.Name = "metroLabel15";
-            this.metroLabel15.Size = new System.Drawing.Size(89, 19);
+            this.metroLabel15.Size = new System.Drawing.Size(94, 20);
             this.metroLabel15.TabIndex = 10;
             this.metroLabel15.Text = "MetroTextBox";
             // 
@@ -891,10 +1057,10 @@
             this.metroLabel12.AutoSize = true;
             this.metroLabel12.Enabled = false;
             this.metroLabel12.LabelMode = MetroFramework.Controls.MetroLabelMode.Selectable;
-            this.metroLabel12.Location = new System.Drawing.Point(148, 100);
-            this.metroLabel12.Margin = new System.Windows.Forms.Padding(3);
+            this.metroLabel12.Location = new System.Drawing.Point(197, 123);
+            this.metroLabel12.Margin = new System.Windows.Forms.Padding(4);
             this.metroLabel12.Name = "metroLabel12";
-            this.metroLabel12.Size = new System.Drawing.Size(157, 19);
+            this.metroLabel12.Size = new System.Drawing.Size(166, 20);
             this.metroLabel12.TabIndex = 9;
             this.metroLabel12.Text = "Disabled Selectable Label";
             // 
@@ -902,10 +1068,10 @@
             // 
             this.metroLabel13.AutoSize = true;
             this.metroLabel13.LabelMode = MetroFramework.Controls.MetroLabelMode.Selectable;
-            this.metroLabel13.Location = new System.Drawing.Point(148, 75);
-            this.metroLabel13.Margin = new System.Windows.Forms.Padding(3);
+            this.metroLabel13.Location = new System.Drawing.Point(197, 92);
+            this.metroLabel13.Margin = new System.Windows.Forms.Padding(4);
             this.metroLabel13.Name = "metroLabel13";
-            this.metroLabel13.Size = new System.Drawing.Size(142, 19);
+            this.metroLabel13.Size = new System.Drawing.Size(150, 20);
             this.metroLabel13.TabIndex = 8;
             this.metroLabel13.Text = "Styled Selectable Label";
             this.metroLabel13.UseStyleColors = true;
@@ -914,10 +1080,10 @@
             // 
             this.metroLabel14.AutoSize = true;
             this.metroLabel14.LabelMode = MetroFramework.Controls.MetroLabelMode.Selectable;
-            this.metroLabel14.Location = new System.Drawing.Point(148, 50);
-            this.metroLabel14.Margin = new System.Windows.Forms.Padding(3);
+            this.metroLabel14.Location = new System.Drawing.Point(197, 62);
+            this.metroLabel14.Margin = new System.Windows.Forms.Padding(4);
             this.metroLabel14.Name = "metroLabel14";
-            this.metroLabel14.Size = new System.Drawing.Size(152, 19);
+            this.metroLabel14.Size = new System.Drawing.Size(159, 20);
             this.metroLabel14.TabIndex = 7;
             this.metroLabel14.Text = "Normal Selectable Label";
             this.metroToolTip.SetToolTip(this.metroLabel14, "Label Tooltip");
@@ -926,20 +1092,20 @@
             // 
             this.metroLabel11.AutoSize = true;
             this.metroLabel11.Enabled = false;
-            this.metroLabel11.Location = new System.Drawing.Point(28, 100);
-            this.metroLabel11.Margin = new System.Windows.Forms.Padding(3);
+            this.metroLabel11.Location = new System.Drawing.Point(37, 123);
+            this.metroLabel11.Margin = new System.Windows.Forms.Padding(4);
             this.metroLabel11.Name = "metroLabel11";
-            this.metroLabel11.Size = new System.Drawing.Size(94, 19);
+            this.metroLabel11.Size = new System.Drawing.Size(99, 20);
             this.metroLabel11.TabIndex = 6;
             this.metroLabel11.Text = "Disabled Label";
             // 
             // metroLabel10
             // 
             this.metroLabel10.AutoSize = true;
-            this.metroLabel10.Location = new System.Drawing.Point(28, 75);
-            this.metroLabel10.Margin = new System.Windows.Forms.Padding(3);
+            this.metroLabel10.Location = new System.Drawing.Point(37, 92);
+            this.metroLabel10.Margin = new System.Windows.Forms.Padding(4);
             this.metroLabel10.Name = "metroLabel10";
-            this.metroLabel10.Size = new System.Drawing.Size(79, 19);
+            this.metroLabel10.Size = new System.Drawing.Size(83, 20);
             this.metroLabel10.TabIndex = 5;
             this.metroLabel10.Text = "Styled Label";
             this.metroLabel10.UseStyleColors = true;
@@ -947,10 +1113,10 @@
             // metroLabel3
             // 
             this.metroLabel3.AutoSize = true;
-            this.metroLabel3.Location = new System.Drawing.Point(28, 50);
-            this.metroLabel3.Margin = new System.Windows.Forms.Padding(3);
+            this.metroLabel3.Location = new System.Drawing.Point(37, 62);
+            this.metroLabel3.Margin = new System.Windows.Forms.Padding(4);
             this.metroLabel3.Name = "metroLabel3";
-            this.metroLabel3.Size = new System.Drawing.Size(89, 19);
+            this.metroLabel3.Size = new System.Drawing.Size(92, 20);
             this.metroLabel3.TabIndex = 4;
             this.metroLabel3.Text = "Normal Label";
             this.metroToolTip.SetToolTip(this.metroLabel3, "Label Tooltip");
@@ -958,28 +1124,48 @@
             // metroTextBox1
             // 
             this.metroTextBox1.BackColor = System.Drawing.SystemColors.ActiveCaption;
+            // 
+            // 
+            // 
+            this.metroTextBox1.CustomButton.Image = null;
+            this.metroTextBox1.CustomButton.Location = new System.Drawing.Point(202, 1);
+            this.metroTextBox1.CustomButton.Margin = new System.Windows.Forms.Padding(5);
+            this.metroTextBox1.CustomButton.Name = "";
+            this.metroTextBox1.CustomButton.Size = new System.Drawing.Size(25, 25);
+            this.metroTextBox1.CustomButton.Style = MetroFramework.MetroColorStyle.Blue;
+            this.metroTextBox1.CustomButton.TabIndex = 1;
+            this.metroTextBox1.CustomButton.Theme = MetroFramework.MetroThemeStyle.Light;
+            this.metroTextBox1.CustomButton.UseSelectable = true;
+            this.metroTextBox1.CustomButton.Visible = false;
             this.metroTextBox1.Lines = new string[] {
         "Normal Textbox"};
-            this.metroTextBox1.Location = new System.Drawing.Point(342, 50);
+            this.metroTextBox1.Location = new System.Drawing.Point(456, 62);
+            this.metroTextBox1.Margin = new System.Windows.Forms.Padding(4);
             this.metroTextBox1.MaxLength = 32767;
             this.metroTextBox1.Name = "metroTextBox1";
             this.metroTextBox1.PasswordChar = '\0';
-            this.metroTextBox1.WaterMark = "With Placeholder support!";
+            this.metroTextBox1.PromptText = "With Placeholder support!";
             this.metroTextBox1.ScrollBars = System.Windows.Forms.ScrollBars.None;
             this.metroTextBox1.SelectedText = "";
-            this.metroTextBox1.Size = new System.Drawing.Size(171, 22);
+            this.metroTextBox1.SelectionLength = 0;
+            this.metroTextBox1.SelectionStart = 0;
+            this.metroTextBox1.ShortcutsEnabled = true;
+            this.metroTextBox1.Size = new System.Drawing.Size(228, 27);
             this.metroTextBox1.TabIndex = 3;
             this.metroTextBox1.Text = "Normal Textbox";
             this.metroToolTip.SetToolTip(this.metroTextBox1, "Textbox Tooltip");
             this.metroTextBox1.UseSelectable = true;
+            this.metroTextBox1.WaterMark = "With Placeholder support!";
+            this.metroTextBox1.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
+            this.metroTextBox1.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
             // 
             // metroLabel2
             // 
             this.metroLabel2.AutoSize = true;
-            this.metroLabel2.Location = new System.Drawing.Point(28, 25);
-            this.metroLabel2.Margin = new System.Windows.Forms.Padding(3);
+            this.metroLabel2.Location = new System.Drawing.Point(37, 31);
+            this.metroLabel2.Margin = new System.Windows.Forms.Padding(4);
             this.metroLabel2.Name = "metroLabel2";
-            this.metroLabel2.Size = new System.Drawing.Size(76, 19);
+            this.metroLabel2.Size = new System.Drawing.Size(79, 20);
             this.metroLabel2.TabIndex = 2;
             this.metroLabel2.Text = "MetroLabel";
             // 
@@ -994,21 +1180,23 @@
             this.metroTabPage6.Controls.Add(this.metroButton6);
             this.metroTabPage6.HorizontalScrollbarBarColor = true;
             this.metroTabPage6.HorizontalScrollbarHighlightOnWheel = false;
-            this.metroTabPage6.HorizontalScrollbarSize = 10;
+            this.metroTabPage6.HorizontalScrollbarSize = 12;
             this.metroTabPage6.Location = new System.Drawing.Point(4, 38);
+            this.metroTabPage6.Margin = new System.Windows.Forms.Padding(4);
             this.metroTabPage6.Name = "metroTabPage6";
-            this.metroTabPage6.Size = new System.Drawing.Size(672, 260);
+            this.metroTabPage6.Size = new System.Drawing.Size(898, 329);
             this.metroTabPage6.TabIndex = 5;
             this.metroTabPage6.Text = "MessageBox";
             this.metroTabPage6.VerticalScrollbarBarColor = true;
             this.metroTabPage6.VerticalScrollbarHighlightOnWheel = false;
-            this.metroTabPage6.VerticalScrollbarSize = 10;
+            this.metroTabPage6.VerticalScrollbarSize = 13;
             // 
             // metroButton12
             // 
-            this.metroButton12.Location = new System.Drawing.Point(229, 130);
+            this.metroButton12.Location = new System.Drawing.Point(305, 160);
+            this.metroButton12.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton12.Name = "metroButton12";
-            this.metroButton12.Size = new System.Drawing.Size(154, 42);
+            this.metroButton12.Size = new System.Drawing.Size(205, 52);
             this.metroButton12.TabIndex = 8;
             this.metroButton12.Text = "Default";
             this.metroButton12.UseSelectable = true;
@@ -1016,9 +1204,10 @@
             // 
             // metroButton11
             // 
-            this.metroButton11.Location = new System.Drawing.Point(446, 16);
+            this.metroButton11.Location = new System.Drawing.Point(595, 20);
+            this.metroButton11.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton11.Name = "metroButton11";
-            this.metroButton11.Size = new System.Drawing.Size(154, 42);
+            this.metroButton11.Size = new System.Drawing.Size(205, 52);
             this.metroButton11.TabIndex = 7;
             this.metroButton11.Text = "Retry Cancel";
             this.metroButton11.UseSelectable = true;
@@ -1026,9 +1215,10 @@
             // 
             // metroButton10
             // 
-            this.metroButton10.Location = new System.Drawing.Point(5, 70);
+            this.metroButton10.Location = new System.Drawing.Point(7, 86);
+            this.metroButton10.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton10.Name = "metroButton10";
-            this.metroButton10.Size = new System.Drawing.Size(154, 42);
+            this.metroButton10.Size = new System.Drawing.Size(205, 52);
             this.metroButton10.TabIndex = 6;
             this.metroButton10.Text = "Ok Cancel";
             this.metroButton10.UseSelectable = true;
@@ -1036,9 +1226,10 @@
             // 
             // metroButton9
             // 
-            this.metroButton9.Location = new System.Drawing.Point(446, 70);
+            this.metroButton9.Location = new System.Drawing.Point(595, 86);
+            this.metroButton9.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton9.Name = "metroButton9";
-            this.metroButton9.Size = new System.Drawing.Size(154, 42);
+            this.metroButton9.Size = new System.Drawing.Size(205, 52);
             this.metroButton9.TabIndex = 5;
             this.metroButton9.Text = "Abort Retry Ignore";
             this.metroButton9.UseSelectable = true;
@@ -1046,9 +1237,10 @@
             // 
             // metroButton8
             // 
-            this.metroButton8.Location = new System.Drawing.Point(229, 70);
+            this.metroButton8.Location = new System.Drawing.Point(305, 86);
+            this.metroButton8.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton8.Name = "metroButton8";
-            this.metroButton8.Size = new System.Drawing.Size(154, 42);
+            this.metroButton8.Size = new System.Drawing.Size(205, 52);
             this.metroButton8.TabIndex = 4;
             this.metroButton8.Text = "Yes No Cancel";
             this.metroButton8.UseSelectable = true;
@@ -1056,9 +1248,10 @@
             // 
             // metroButton7
             // 
-            this.metroButton7.Location = new System.Drawing.Point(229, 16);
+            this.metroButton7.Location = new System.Drawing.Point(305, 20);
+            this.metroButton7.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton7.Name = "metroButton7";
-            this.metroButton7.Size = new System.Drawing.Size(154, 42);
+            this.metroButton7.Size = new System.Drawing.Size(205, 52);
             this.metroButton7.TabIndex = 3;
             this.metroButton7.Text = "Yes No";
             this.metroButton7.UseSelectable = true;
@@ -1066,9 +1259,10 @@
             // 
             // metroButton6
             // 
-            this.metroButton6.Location = new System.Drawing.Point(5, 16);
+            this.metroButton6.Location = new System.Drawing.Point(7, 20);
+            this.metroButton6.Margin = new System.Windows.Forms.Padding(4);
             this.metroButton6.Name = "metroButton6";
-            this.metroButton6.Size = new System.Drawing.Size(154, 42);
+            this.metroButton6.Size = new System.Drawing.Size(205, 52);
             this.metroButton6.TabIndex = 2;
             this.metroButton6.Text = "Ok";
             this.metroButton6.UseSelectable = true;
@@ -1079,16 +1273,17 @@
             this.metroTabPage7.Controls.Add(this.metroGrid1);
             this.metroTabPage7.HorizontalScrollbarBarColor = true;
             this.metroTabPage7.HorizontalScrollbarHighlightOnWheel = false;
-            this.metroTabPage7.HorizontalScrollbarSize = 10;
+            this.metroTabPage7.HorizontalScrollbarSize = 12;
             this.metroTabPage7.Location = new System.Drawing.Point(4, 38);
+            this.metroTabPage7.Margin = new System.Windows.Forms.Padding(4);
             this.metroTabPage7.Name = "metroTabPage7";
-            this.metroTabPage7.Padding = new System.Windows.Forms.Padding(0, 5, 0, 0);
-            this.metroTabPage7.Size = new System.Drawing.Size(672, 260);
+            this.metroTabPage7.Padding = new System.Windows.Forms.Padding(0, 6, 0, 0);
+            this.metroTabPage7.Size = new System.Drawing.Size(898, 329);
             this.metroTabPage7.TabIndex = 6;
             this.metroTabPage7.Text = "Grid";
             this.metroTabPage7.VerticalScrollbarBarColor = true;
             this.metroTabPage7.VerticalScrollbarHighlightOnWheel = false;
-            this.metroTabPage7.VerticalScrollbarSize = 10;
+            this.metroTabPage7.VerticalScrollbarSize = 13;
             // 
             // metroGrid1
             // 
@@ -1120,7 +1315,8 @@
             this.metroGrid1.Font = new System.Drawing.Font("Segoe UI", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
             this.metroGrid1.GridColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
             this.metroGrid1.HighLightPercentage = 0.5F;
-            this.metroGrid1.Location = new System.Drawing.Point(0, 5);
+            this.metroGrid1.Location = new System.Drawing.Point(0, 6);
+            this.metroGrid1.Margin = new System.Windows.Forms.Padding(4);
             this.metroGrid1.Name = "metroGrid1";
             this.metroGrid1.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
             dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
@@ -1134,7 +1330,7 @@
             this.metroGrid1.RowHeadersVisible = false;
             this.metroGrid1.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.DisableResizing;
             this.metroGrid1.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.metroGrid1.Size = new System.Drawing.Size(672, 255);
+            this.metroGrid1.Size = new System.Drawing.Size(898, 323);
             this.metroGrid1.TabIndex = 2;
             // 
             // metroTabPage5
@@ -1148,22 +1344,24 @@
             this.metroTabPage5.Controls.Add(this.label1);
             this.metroTabPage5.HorizontalScrollbarBarColor = true;
             this.metroTabPage5.HorizontalScrollbarHighlightOnWheel = false;
-            this.metroTabPage5.HorizontalScrollbarSize = 10;
+            this.metroTabPage5.HorizontalScrollbarSize = 12;
             this.metroTabPage5.Location = new System.Drawing.Point(4, 38);
+            this.metroTabPage5.Margin = new System.Windows.Forms.Padding(4);
             this.metroTabPage5.Name = "metroTabPage5";
-            this.metroTabPage5.Size = new System.Drawing.Size(672, 260);
+            this.metroTabPage5.Size = new System.Drawing.Size(898, 329);
             this.metroTabPage5.TabIndex = 4;
             this.metroTabPage5.Text = "Legacy";
             this.metroTabPage5.VerticalScrollbarBarColor = true;
             this.metroTabPage5.VerticalScrollbarHighlightOnWheel = false;
-            this.metroTabPage5.VerticalScrollbarSize = 10;
+            this.metroTabPage5.VerticalScrollbarSize = 13;
             // 
             // metroTile5
             // 
             this.metroTile5.ActiveControl = null;
-            this.metroTile5.Location = new System.Drawing.Point(159, 175);
+            this.metroTile5.Location = new System.Drawing.Point(212, 215);
+            this.metroTile5.Margin = new System.Windows.Forms.Padding(4);
             this.metroTile5.Name = "metroTile5";
-            this.metroTile5.Size = new System.Drawing.Size(56, 51);
+            this.metroTile5.Size = new System.Drawing.Size(75, 63);
             this.metroTile5.Style = MetroFramework.MetroColorStyle.Red;
             this.metroTile5.TabIndex = 8;
             this.metroTile5.Text = "metroTile5";
@@ -1172,9 +1370,10 @@
             // metroTile4
             // 
             this.metroTile4.ActiveControl = null;
-            this.metroTile4.Location = new System.Drawing.Point(97, 175);
+            this.metroTile4.Location = new System.Drawing.Point(129, 215);
+            this.metroTile4.Margin = new System.Windows.Forms.Padding(4);
             this.metroTile4.Name = "metroTile4";
-            this.metroTile4.Size = new System.Drawing.Size(56, 51);
+            this.metroTile4.Size = new System.Drawing.Size(75, 63);
             this.metroTile4.Style = MetroFramework.MetroColorStyle.Orange;
             this.metroTile4.TabIndex = 7;
             this.metroTile4.Text = "metroTile4";
@@ -1183,9 +1382,10 @@
             // metroTile3
             // 
             this.metroTile3.ActiveControl = null;
-            this.metroTile3.Location = new System.Drawing.Point(35, 175);
+            this.metroTile3.Location = new System.Drawing.Point(47, 215);
+            this.metroTile3.Margin = new System.Windows.Forms.Padding(4);
             this.metroTile3.Name = "metroTile3";
-            this.metroTile3.Size = new System.Drawing.Size(56, 51);
+            this.metroTile3.Size = new System.Drawing.Size(75, 63);
             this.metroTile3.Style = MetroFramework.MetroColorStyle.Lime;
             this.metroTile3.TabIndex = 6;
             this.metroTile3.Text = "metroTile3";
@@ -1195,27 +1395,30 @@
             // 
             this.metroStyleExtender.SetApplyMetroTheme(this.propertyGrid1, true);
             this.propertyGrid1.CategoryForeColor = System.Drawing.SystemColors.InactiveCaptionText;
-            this.propertyGrid1.Location = new System.Drawing.Point(280, 19);
+            this.propertyGrid1.Location = new System.Drawing.Point(373, 23);
+            this.propertyGrid1.Margin = new System.Windows.Forms.Padding(4);
             this.propertyGrid1.Name = "propertyGrid1";
             this.propertyGrid1.SelectedObject = this;
-            this.propertyGrid1.Size = new System.Drawing.Size(256, 230);
+            this.propertyGrid1.Size = new System.Drawing.Size(341, 283);
             this.propertyGrid1.TabIndex = 5;
             // 
             // richTextBox1
             // 
             this.metroStyleExtender.SetApplyMetroTheme(this.richTextBox1, true);
-            this.richTextBox1.Location = new System.Drawing.Point(29, 78);
+            this.richTextBox1.Location = new System.Drawing.Point(39, 96);
+            this.richTextBox1.Margin = new System.Windows.Forms.Padding(4);
             this.richTextBox1.Name = "richTextBox1";
-            this.richTextBox1.Size = new System.Drawing.Size(197, 90);
+            this.richTextBox1.Size = new System.Drawing.Size(261, 110);
             this.richTextBox1.TabIndex = 4;
             this.richTextBox1.Text = "This RichTextBox has ApplyMetroTheme=true\nDoes it work?";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(32, 53);
+            this.label2.Location = new System.Drawing.Point(43, 65);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(194, 13);
+            this.label2.Size = new System.Drawing.Size(260, 17);
             this.label2.TabIndex = 3;
             this.label2.Text = "Legacy Label (ApplyMetroTheme=false)";
             // 
@@ -1223,9 +1426,10 @@
             // 
             this.metroStyleExtender.SetApplyMetroTheme(this.label1, true);
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(32, 23);
+            this.label1.Location = new System.Drawing.Point(43, 28);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(190, 13);
+            this.label1.Size = new System.Drawing.Size(255, 17);
             this.label1.TabIndex = 2;
             this.label1.Text = "Legacy Label (ApplyMetroTheme=true)";
             // 
@@ -1241,6 +1445,7 @@
             // 
             // metroContextMenu1
             // 
+            this.metroContextMenu1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.metroContextMenu1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.maintenanceToolStripMenuItem,
@@ -1249,54 +1454,56 @@
             this.toolStripMenuItem1,
             this.exitToolStripMenuItem});
             this.metroContextMenu1.Name = "metroContextMenu1";
-            this.metroContextMenu1.Size = new System.Drawing.Size(144, 120);
+            this.metroContextMenu1.Size = new System.Drawing.Size(164, 130);
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(163, 24);
             this.fileToolStripMenuItem.Text = "&File";
             // 
             // maintenanceToolStripMenuItem
             // 
             this.maintenanceToolStripMenuItem.Name = "maintenanceToolStripMenuItem";
-            this.maintenanceToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
+            this.maintenanceToolStripMenuItem.Size = new System.Drawing.Size(163, 24);
             this.maintenanceToolStripMenuItem.Text = "&Maintenance";
             // 
             // toolsToolStripMenuItem
             // 
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(163, 24);
             this.toolsToolStripMenuItem.Text = "&Tools";
             // 
             // settingsToolStripMenuItem
             // 
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(163, 24);
             this.settingsToolStripMenuItem.Text = "&Settings";
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(140, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(160, 6);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(163, 24);
             this.exitToolStripMenuItem.Text = "E&xit";
             // 
             // MainForm
             // 
             this.ApplyImageInvert = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackImage = global::MetroFramework.Demo.Properties.Resources.GitHub_Mark;
             this.BackImagePadding = new System.Windows.Forms.Padding(210, 10, 0, 0);
             this.BackMaxSize = 50;
-            this.ClientSize = new System.Drawing.Size(720, 382);
+            this.ClientSize = new System.Drawing.Size(960, 470);
             this.Controls.Add(this.metroTabControl1);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "MainForm";
+            this.Padding = new System.Windows.Forms.Padding(27, 74, 27, 25);
             this.ShadowType = MetroFramework.Forms.MetroFormShadowType.None;
             this.StyleManager = this.metroStyleManager;
             this.Text = "metro framework";
@@ -1417,7 +1624,9 @@
         private Controls.MetroLabel metroLabel22;
         private Controls.MetroRadioButton metroRadioButton6;
         private Controls.MetroCheckBox metroCheckBox6;
-
+        private Controls.MetroComboBox metroComboBox3;
+        private System.Windows.Forms.TextBox textBox1;
+        private Controls.MetroComboBox metroComboBox4;
     }
 }
 

--- a/MetroFramework.Demo/MainForm.Designer.cs
+++ b/MetroFramework.Demo/MainForm.Designer.cs
@@ -1,5 +1,4 @@
-﻿using MetroFramework.Extensions;
-
+﻿
 namespace MetroFramework.Demo
 {
     partial class MainForm
@@ -58,7 +57,6 @@ namespace MetroFramework.Demo
             this.metroTile1 = new MetroFramework.Controls.MetroTile();
             this.metroTabPage2 = new MetroFramework.Controls.MetroTabPage();
             this.metroComboBox4 = new MetroFramework.Controls.MetroComboBox();
-            this.textBox1 = new System.Windows.Forms.TextBox();
             this.metroComboBox3 = new MetroFramework.Controls.MetroComboBox();
             this.metroDateTime2 = new MetroFramework.Controls.MetroDateTime();
             this.metroLabel20 = new MetroFramework.Controls.MetroLabel();
@@ -439,7 +437,6 @@ namespace MetroFramework.Demo
             // metroTabPage2
             // 
             this.metroTabPage2.Controls.Add(this.metroComboBox4);
-            this.metroTabPage2.Controls.Add(this.textBox1);
             this.metroTabPage2.Controls.Add(this.metroComboBox3);
             this.metroTabPage2.Controls.Add(this.metroDateTime2);
             this.metroTabPage2.Controls.Add(this.metroLabel20);
@@ -492,13 +489,6 @@ namespace MetroFramework.Demo
             this.metroToolTip.SetToolTip(this.metroComboBox4, "ComboBox Tooltip");
             this.metroComboBox4.UseSelectable = true;
             // 
-            // textBox1
-            // 
-            this.textBox1.Location = new System.Drawing.Point(604, 291);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(258, 22);
-            this.textBox1.TabIndex = 22;
-            // 
             // metroComboBox3
             // 
             this.metroComboBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
@@ -520,7 +510,6 @@ namespace MetroFramework.Demo
             this.metroComboBox3.TabIndex = 21;
             this.metroToolTip.SetToolTip(this.metroComboBox3, "ComboBox Tooltip");
             this.metroComboBox3.UseSelectable = true;
-            this.metroComboBox3.TextChanged += new System.EventHandler(this.metroComboBox3_TextChanged);
             // 
             // metroDateTime2
             // 
@@ -1454,41 +1443,41 @@ namespace MetroFramework.Demo
             this.toolStripMenuItem1,
             this.exitToolStripMenuItem});
             this.metroContextMenu1.Name = "metroContextMenu1";
-            this.metroContextMenu1.Size = new System.Drawing.Size(164, 130);
+            this.metroContextMenu1.Size = new System.Drawing.Size(170, 140);
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(163, 24);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(169, 26);
             this.fileToolStripMenuItem.Text = "&File";
             // 
             // maintenanceToolStripMenuItem
             // 
             this.maintenanceToolStripMenuItem.Name = "maintenanceToolStripMenuItem";
-            this.maintenanceToolStripMenuItem.Size = new System.Drawing.Size(163, 24);
+            this.maintenanceToolStripMenuItem.Size = new System.Drawing.Size(169, 26);
             this.maintenanceToolStripMenuItem.Text = "&Maintenance";
             // 
             // toolsToolStripMenuItem
             // 
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(163, 24);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(169, 26);
             this.toolsToolStripMenuItem.Text = "&Tools";
             // 
             // settingsToolStripMenuItem
             // 
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(163, 24);
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(169, 26);
             this.settingsToolStripMenuItem.Text = "&Settings";
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(160, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(166, 6);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(163, 24);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(169, 26);
             this.exitToolStripMenuItem.Text = "E&xit";
             // 
             // MainForm
@@ -1625,7 +1614,6 @@ namespace MetroFramework.Demo
         private Controls.MetroRadioButton metroRadioButton6;
         private Controls.MetroCheckBox metroCheckBox6;
         private Controls.MetroComboBox metroComboBox3;
-        private System.Windows.Forms.TextBox textBox1;
         private Controls.MetroComboBox metroComboBox4;
     }
 }

--- a/MetroFramework.Demo/MainForm.cs
+++ b/MetroFramework.Demo/MainForm.cs
@@ -5,6 +5,7 @@ using System.Windows.Forms;
 
 using MetroFramework.Forms;
 using System.Data;
+using MetroFramework.Extensions;
 
 namespace MetroFramework.Demo
 {
@@ -14,12 +15,19 @@ namespace MetroFramework.Demo
         {
             InitializeComponent();
 
+            this.BorderStyle = MetroFormBorderStyle.FixedSingle;
+            this.ShadowType = MetroFormShadowType.AeroShadow;
+
             DataTable _table = new DataTable();
             _table.ReadXml(Application.StartupPath + @"\Data\Books.xml");
             metroGrid1.DataSource = _table;
 
             metroGrid1.Font = new Font("Segoe UI", 11f, FontStyle.Regular, GraphicsUnit.Pixel);
             metroGrid1.AllowUserToAddRows = false;
+
+            this.metroComboBox4.DataSource = _table;
+            metroComboBox4.ValueMember = "Id";
+            metroComboBox4.DisplayMember = "title";
         }
 
         private void metroTileSwitch_Click(object sender, EventArgs e)
@@ -87,6 +95,11 @@ namespace MetroFramework.Demo
         private void metroButton4_Click(object sender, EventArgs e)
         {
             metroTextBox2.Focus();
+        }
+
+        private void metroComboBox3_TextChanged(object sender, EventArgs e)
+        {
+            textBox1.Text = metroComboBox3.Text;
         }
     }
 }

--- a/MetroFramework.Demo/MainForm.cs
+++ b/MetroFramework.Demo/MainForm.cs
@@ -5,7 +5,6 @@ using System.Windows.Forms;
 
 using MetroFramework.Forms;
 using System.Data;
-using MetroFramework.Extensions;
 
 namespace MetroFramework.Demo
 {
@@ -97,9 +96,5 @@ namespace MetroFramework.Demo
             metroTextBox2.Focus();
         }
 
-        private void metroComboBox3_TextChanged(object sender, EventArgs e)
-        {
-            textBox1.Text = metroComboBox3.Text;
-        }
-    }
+     }
 }

--- a/MetroFramework/Controls/MetroComboBox.cs
+++ b/MetroFramework/Controls/MetroComboBox.cs
@@ -29,12 +29,20 @@ using System.Windows.Forms;
 using MetroFramework.Components;
 using MetroFramework.Interfaces;
 using MetroFramework.Drawing;
+using System.Collections.Generic;
+using System.Windows.Forms.Design;
+using System.ComponentModel.Design;
 
 namespace MetroFramework.Controls
 {
     [ToolboxBitmap(typeof(ComboBox))]
     public class MetroComboBox : ComboBox, IMetroControl
     {
+
+        #region Edit Control
+        private MetroTextBox textBox = new MetroTextBox();
+        #endregion
+
         #region Interface
 
         [Category(MetroDefaults.PropertyCategory.Appearance)]
@@ -164,6 +172,16 @@ namespace MetroFramework.Controls
             set { SetStyle(ControlStyles.Selectable, value); }
         }
 
+        [Browsable(true)]
+        [Category(MetroDefaults.PropertyCategory.Behaviour)]
+        [DefaultValue("")]
+        [Description("Gets or sets the text associated with this control.")]
+        public override string Text
+        {
+            get { return textBox.Text; }
+            set { textBox.Text = value; base.Text = textBox.Text;  OnTextChanged(EventArgs.Empty);  }
+        }
+
         #endregion
 
         #region Fields
@@ -185,12 +203,28 @@ namespace MetroFramework.Controls
             set { base.DrawMode = DrawMode.OwnerDrawFixed; }
         }
 
+        private ComboBoxStyle dropDownStyle = ComboBoxStyle.DropDownList;
         [DefaultValue(ComboBoxStyle.DropDownList)]
-        [Browsable(false)]
+        [Category(MetroDefaults.PropertyCategory.Appearance)]
+        [Browsable(true)]
         public new ComboBoxStyle DropDownStyle
         {
-            get { return ComboBoxStyle.DropDownList; }
-            set { base.DropDownStyle = ComboBoxStyle.DropDownList; }
+            get { return dropDownStyle; }
+            set
+            {
+                // we don't support the Simple style
+                if (value == ComboBoxStyle.Simple)
+                    value = ComboBoxStyle.DropDownList;
+                dropDownStyle = value;
+                // fake out the base
+                base.DropDownStyle = ComboBoxStyle.DropDownList;
+                // if we are a dropdown and have focus, then show the edit box
+                if ((value == ComboBoxStyle.DropDown) && (this.Focused))
+                    textBox.Visible = true;
+                else
+                    textBox.Visible = false;
+                Invalidate();
+            }
         }
 
         private MetroComboBoxSize metroComboBoxSize = MetroComboBoxSize.Medium;
@@ -222,6 +256,9 @@ namespace MetroFramework.Controls
             set
             {
                 promptText = value.Trim();
+                // when we are drop down, use the watermark property of the textbox to show the prompt text
+                if (DropDownStyle == ComboBoxStyle.DropDown)
+                    textBox.WaterMark = promptText;
                 Invalidate();
             }
         }
@@ -241,6 +278,50 @@ namespace MetroFramework.Controls
             }
         }
 
+        private AutoCompleteMode autoCompleteMode = AutoCompleteMode.None;
+        public new AutoCompleteMode AutoCompleteMode
+        {
+            get { return autoCompleteMode; }
+            set
+            {
+                autoCompleteMode = value;
+                textBox.AutoCompleteMode = value;
+                if (value != AutoCompleteMode.None)
+                {
+                    // if using autocomplete, then the source will be the item list.
+                    textBox.AutoCompleteSource = AutoCompleteSource.CustomSource;
+                    textBox.AutoCompleteCustomSource = new AutoCompleteStringCollection();
+                    foreach (object item in this.Items)
+                    {
+                        textBox.AutoCompleteCustomSource.Add(item.ToString());
+                    }
+                }
+                else
+                {
+                    textBox.AutoCompleteSource = AutoCompleteSource.None;
+                    textBox.AutoCompleteCustomSource = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Hide the AutoCompleteSource since it isn't applicable here
+        /// </summary>
+        [Browsable(false)]
+        public new AutoCompleteSource AutoCompleteSource
+        {
+            get { return AutoCompleteSource.None; } set { base.AutoCompleteSource = AutoCompleteSource.None; }
+        }
+
+        /// <summary>
+        /// Hide the AutoCompleteCustomSource since it isn't applicable here
+        /// </summary>
+        [Browsable(false)]
+        public new AutoCompleteStringCollection AutoCompleteCustomSource
+        {
+            get { return base.AutoCompleteCustomSource; } set { base.AutoCompleteCustomSource = value; }
+        }
+
         private bool isHovered = false;
         private bool isPressed = false;
         private bool isFocused = false;
@@ -255,16 +336,76 @@ namespace MetroFramework.Controls
                      ControlStyles.OptimizedDoubleBuffer |
                      ControlStyles.ResizeRedraw |
                      ControlStyles.UserPaint, true);
+            DropDownStyle = ComboBoxStyle.DropDownList;
 
             base.DrawMode = DrawMode.OwnerDrawFixed;
-            base.DropDownStyle = ComboBoxStyle.DropDownList;
 
             drawPrompt = (SelectedIndex == -1);
+
+            // setup the textbox
+            this.SuspendLayout();
+            textBox.Location = new System.Drawing.Point(0, 0);
+            textBox.FontSize = (MetroTextBoxSize)metroComboBoxSize;
+            textBox.FontWeight = (MetroTextBoxWeight)metroComboBoxWeight;
+            textBox.WaterMarkFont = MetroFonts.ComboBox(metroComboBoxSize, metroComboBoxWeight);
+            textBox.Size = this.Size;
+            textBox.TabIndex = 0;
+            textBox.Margin = new Padding(0);
+            textBox.Padding = new Padding(0);
+            textBox.TextAlign = HorizontalAlignment.Left;
+            textBox.Resize += TextBox_Resize;
+            textBox.TextChanged +=  TextBox_TextChanged;
+            textBox.UseSelectable = true;
+            textBox.Enter += TextBox_Enter;
+            textBox.Visible = false;
+
+
+            this.Controls.Add(textBox);
+            this.ResumeLayout(true);
+            this.AdjustControls();
+
+                        
         }
+
 
         #endregion
 
+        #region TextBox Methods
+
+        private void TextBox_Enter(object sender, EventArgs e)
+        {
+            // if the list changes and we have autocomplete enabled, then we have to re-read the item list into the autocompletesource
+            // we have to rebuild the autocomplete source here because we are running .net 2.0 and 
+            // cannot use and observable on Items to know when it has changed
+            if (this.autoCompleteMode != AutoCompleteMode.None)
+            {
+                textBox.AutoCompleteSource = AutoCompleteSource.CustomSource;
+                textBox.AutoCompleteCustomSource = new AutoCompleteStringCollection();
+               
+                for (int i = 0; i < Items.Count; i++)
+                    textBox.AutoCompleteCustomSource.Add(GetItemText(Items[i]));
+            }
+        }
+
+        private void TextBox_Resize(object sender, EventArgs e)
+        {
+            AdjustControls();
+        }
+
+        private void TextBox_TextChanged(object sender, EventArgs e)
+        {
+            this.promptText = textBox.Text;
+            OnTextChanged(e);
+        }
+        #endregion
+
         #region Paint Methods
+
+        protected override void OnSizeChanged(EventArgs e)
+        {
+            AdjustControls();
+            base.OnSizeChanged(e);
+        }
 
         protected override void OnPaintBackground(PaintEventArgs e)
         {
@@ -303,6 +444,8 @@ namespace MetroFramework.Controls
                 }
 
                 OnCustomPaint(new MetroPaintEventArgs(Color.Empty, Color.Empty, e.Graphics));
+                
+
                 OnPaintForeground(e);
             }
             catch
@@ -344,24 +487,33 @@ namespace MetroFramework.Controls
                 e.Graphics.DrawRectangle(p, boxRect);
             }
 
-            using (SolidBrush b = new SolidBrush(foreColor))
+  
+            if (DropDownStyle != ComboBoxStyle.Simple)
             {
-                e.Graphics.FillPolygon(b, new Point[] { new Point(Width - 20, (Height / 2) - 2), new Point(Width - 9, (Height / 2) - 2), new Point(Width - 15, (Height / 2) + 4) });
+                using (SolidBrush b = new SolidBrush(foreColor))
+                {
+                    e.Graphics.FillPolygon(b, new Point[] { new Point(Width - 20, (Height / 2) - 2), new Point(Width - 9, (Height / 2) - 2), new Point(Width - 15, (Height / 2) + 4) });
+                }
+
+                Rectangle textRect = new Rectangle(2, 2, Width - 40, Height - 4);
+
+                if (Enabled)
+                    TextRenderer.DrawText(e.Graphics, Text, MetroFonts.ComboBox(metroComboBoxSize, metroComboBoxWeight), textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+                else
+                    ControlPaint.DrawStringDisabled(e.Graphics, Text, MetroFonts.ComboBox(metroComboBoxSize, metroComboBoxWeight), MetroPaint.ForeColor.ComboBox.Disabled(Theme), textRect, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+
+                OnCustomPaintForeground(new MetroPaintEventArgs(Color.Empty, foreColor, e.Graphics));
+                if (displayFocusRectangle && isFocused)
+                    ControlPaint.DrawFocusRectangle(e.Graphics, ClientRectangle);
+
+                if (drawPrompt)
+                {
+                    DrawTextPrompt(e.Graphics);
+                }
             }
+            
 
-            Rectangle textRect = new Rectangle(2, 2, Width - 20, Height - 4);
 
-            TextRenderer.DrawText(e.Graphics, Text, MetroFonts.ComboBox(metroComboBoxSize, metroComboBoxWeight), textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
-
-            OnCustomPaintForeground(new MetroPaintEventArgs(Color.Empty, foreColor, e.Graphics));
-
-            if (displayFocusRectangle && isFocused)
-                ControlPaint.DrawFocusRectangle(e.Graphics, ClientRectangle);
-
-            if (drawPrompt)
-            {
-                DrawTextPrompt(e.Graphics);
-            }
         }
 
         protected override void OnDrawItem(DrawItemEventArgs e)
@@ -393,8 +545,16 @@ namespace MetroFramework.Controls
                     }
                 }
 
-                Rectangle textRect = new Rectangle(0, e.Bounds.Top, e.Bounds.Width, e.Bounds.Height);
-                TextRenderer.DrawText(e.Graphics, GetItemText(Items[e.Index]), MetroFonts.ComboBox(metroComboBoxSize, metroComboBoxWeight), textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+                if (this.DropDownStyle != ComboBoxStyle.DropDown)
+                {
+                    Rectangle textRect = new Rectangle(0, e.Bounds.Top, e.Bounds.Width, e.Bounds.Height);
+                    TextRenderer.DrawText(e.Graphics, GetItemText(Items[e.Index]), MetroFonts.ComboBox(metroComboBoxSize, metroComboBoxWeight), textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+                }
+                else
+                {
+                    Rectangle textRect = new Rectangle(0, e.Bounds.Top, this.textBox.Width, e.Bounds.Height);
+                    TextRenderer.DrawText(e.Graphics, GetItemText(Items[e.Index]), MetroFonts.ComboBox(metroComboBoxSize, metroComboBoxWeight), textRect, foreColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+                }
             }
             else
             {
@@ -404,6 +564,7 @@ namespace MetroFramework.Controls
 
         private void DrawTextPrompt()
         {
+
             using (Graphics graphics = CreateGraphics())
             {
                 DrawTextPrompt(graphics);
@@ -418,9 +579,8 @@ namespace MetroFramework.Controls
             {
                 backColor = MetroPaint.BackColor.Form(Theme);
             }
-
-            Rectangle textRect = new Rectangle(2, 2, Width - 20, Height - 4);
-            TextRenderer.DrawText(g, promptText, MetroFonts.ComboBox(metroComboBoxSize, metroComboBoxWeight), textRect, SystemColors.GrayText, backColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+                Rectangle textRect = new Rectangle(2, 2, Width - 20, Height - 4);
+                TextRenderer.DrawText(g, promptText, MetroFonts.ComboBox(metroComboBoxSize, metroComboBoxWeight), textRect, SystemColors.GrayText, backColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
         }
 
         #endregion
@@ -431,6 +591,7 @@ namespace MetroFramework.Controls
         {
             isFocused = true;
             isHovered = true;
+            
             Invalidate();
 
             base.OnGotFocus(e);
@@ -441,6 +602,7 @@ namespace MetroFramework.Controls
             isFocused = false;
             isHovered = false;
             isPressed = false;
+            
             Invalidate();
 
             base.OnLostFocus(e);
@@ -453,6 +615,9 @@ namespace MetroFramework.Controls
             Invalidate();
 
             base.OnEnter(e);
+
+            
+
         }
 
         protected override void OnLeave(EventArgs e)
@@ -460,6 +625,8 @@ namespace MetroFramework.Controls
             isFocused = false;
             isHovered = false;
             isPressed = false;
+            if (DropDownStyle == ComboBoxStyle.DropDown)
+                textBox.Visible = false;
             Invalidate();
 
             base.OnLeave(e);
@@ -506,6 +673,8 @@ namespace MetroFramework.Controls
         {
             if (e.Button == MouseButtons.Left)
             {
+                if (DropDownStyle == ComboBoxStyle.DropDown)
+                    textBox.Visible = true;
                 isPressed = true;
                 Invalidate();
             }
@@ -576,5 +745,23 @@ namespace MetroFramework.Controls
         }
 
         #endregion
+
+        #region Private Methods
+        private void AdjustControls()
+        {
+            if (DropDownStyle == ComboBoxStyle.DropDownList)
+                return;
+
+            this.SuspendLayout();
+            textBox.Width = ClientRectangle.Width - 26;
+            textBox.Height = ClientRectangle.Height;
+            this.ResumeLayout();
+            this.Invalidate(false);
+        }
+
+       
+        #endregion
     }
+
+   
 }

--- a/MetroFramework/Controls/MetroComboBox.cs
+++ b/MetroFramework/Controls/MetroComboBox.cs
@@ -304,18 +304,12 @@ namespace MetroFramework.Controls
             }
         }
 
-        /// <summary>
-        /// Hide the AutoCompleteSource since it isn't applicable here
-        /// </summary>
         [Browsable(false)]
         public new AutoCompleteSource AutoCompleteSource
         {
-            get { return AutoCompleteSource.None; } set { base.AutoCompleteSource = AutoCompleteSource.None; }
+            get { return base.AutoCompleteSource; } set { base.AutoCompleteSource = value; }
         }
 
-        /// <summary>
-        /// Hide the AutoCompleteCustomSource since it isn't applicable here
-        /// </summary>
         [Browsable(false)]
         public new AutoCompleteStringCollection AutoCompleteCustomSource
         {

--- a/MetroFramework/MetroFramework.csproj
+++ b/MetroFramework/MetroFramework.csproj
@@ -80,6 +80,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Data" />
@@ -146,9 +147,7 @@
     <Compile Include="Controls\MetroScrollBar.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="Controls\MetroTabControl.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="Controls\MetroTabControl.cs" />
     <Compile Include="Controls\MetroTabPage.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
I have modified the combo box to support the Drop Down style, which is the style which enabled and editing control in the combo box so the user can add an item that is not in the supplied item list.

This modification also support AutoComplete, which if set to something other than None will provide AutoComplete for the Items in the list.

Databinding is supported, as well as all other combo box operations.  

I have added this feature so that I can use it in another modification that I will be publishing soon.

Enjoy!