### PR TITLE
Enable custom colors both for GetStyleBrush and GetStyleColor

### DIFF
--- a/MetroFramework/Drawing/MetroPaint.cs
+++ b/MetroFramework/Drawing/MetroPaint.cs
@@ -749,6 +749,9 @@ namespace MetroFramework.Drawing
 
                 case MetroColorStyle.Yellow:
                     return MetroColors.Yellow;
+                
+                case MetroColorStyle.Custom:
+                    return MetroColors.Custom;
 
                 default:
                     return MetroColors.Blue;
@@ -800,6 +803,9 @@ namespace MetroFramework.Drawing
 
                 case MetroColorStyle.Yellow:
                     return MetroBrushes.Yellow;
+                
+                case MetroColorStyle.Custom:
+                    return MetroBrushes.Custom;
 
                 default:
                     return MetroBrushes.Blue;


### PR DESCRIPTION
Enable custom colors both for GetStyleBrush and GetStyleColor, the reason behind this push is to enable users to set any custom style they need on their applications, not just the pre-selected ones.

Fixes #132 